### PR TITLE
Updated to read initial runtime state event

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,4 @@ Example if IP address is 127.0.0.1 (local host): file:///Users/cg/Documents/ProP
  
  
 **Known bugs:**
-
-When first opening the HTML page, the NEXT event container will not show any text. As soon as a new timer has been started or the text is edited this will update.
+- 

--- a/index.html
+++ b/index.html
@@ -145,6 +145,26 @@
       return `${totalSeconds < 0 ? '- ' : ''}${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
     }
 
+    /**
+     * @param message {string} - The message to set.
+     */
+    function updateNowMessage(message) {
+      const element = document.getElementById("nowContent");
+      if (element) {
+        element.innerText = message;
+      }
+    }
+
+    /**
+     * @param message {string} - The message to set
+     */
+    function updateNextMessage(message) {
+      const element = document.querySelector("#nextMessage .title-card__title");
+      if (element) {
+        element.innerText = message;
+      }
+    }
+    
     const ws = new WebSocket(wsUrl);
 
     ws.onopen = () => {
@@ -174,11 +194,25 @@
       }
       
       if (message.type === "ontime-eventNow" && message.payload && message.payload.title) {
-        document.getElementById("nowContent").innerText = message.payload.title;
+        updateNowMessage(message.payload.title);
       }
       
       if (message.type === "ontime-eventNext" && message.payload && message.payload.title) {
-        document.querySelector("#nextMessage .title-card__title").innerText = message.payload.title;
+        updateNextMessage(message.payload.title);
+      }
+
+      if (message.type === "ontime" && message.payload) {
+        // Handle initial connection / Runtime data object
+        // https://docs.getontime.no/api/data/runtime-data
+        const nowEvent = message.payload.eventNow;
+        if (nowEvent && nowEvent.title) {
+          updateNowMessage(nowEvent.title);
+        }
+
+        const nextEvent = message.payload.eventNext;
+        if (nextEvent && nextEvent.title) {
+          updateNextMessage(nextEvent.title);
+        }
       }
     };
 


### PR DESCRIPTION
Fixed NEXT Event Container showing blank on initial startup, by adding a handler for the 'runtime data' event, which is emitted by Ontime on a new websocket connection.
Docs: https://docs.getontime.no/api/data/runtime-data

https://github.com/user-attachments/assets/68f0e178-146f-40e7-a428-4133d57c4c3c
(It's not super obvious, but the page is refreshed part way though the video)

From Ontime config:
<img width="1504" alt="image" src="https://github.com/user-attachments/assets/70f5d808-030c-4f7e-b094-d139f39231b9" />

